### PR TITLE
Facebook plugin

### DIFF
--- a/control/content/index.html
+++ b/control/content/index.html
@@ -29,7 +29,7 @@
         <div class="item clearfix row" ng-show="idEmpty">
             <div class="labels col-md-2 padding-right-zero pull-left"></div>
             <div class="col-md-10 pull-left">
-                <div class="alert alert-danger transition-half">Please enter Facebook ID</div>
+                <div class="alert alert-danger transition-half">Please enter Facebook URL</div>
             </div>
         </div>
     </div>

--- a/control/content/index.html
+++ b/control/content/index.html
@@ -10,7 +10,7 @@
     <script src="../../../../scripts/buildfire.js"></script>
     <script src="../../../../scripts/angular/angular.min.js"></script>
 </head>
-<body ng-controller="facebookPluginCtrl" id="webviewApp" ng-cloak>
+<body ng-controller="facebookPluginCtrl" id="webviewApp" ng-cloak ng-show="datastoreInitialized">
     <div ng-form="frmMain">
         <div class="item clearfix row margin-bottom-fifteen">
             <div class="labels col-md-2 padding-right-zero pull-left">
@@ -41,11 +41,19 @@
             var timer = null,
                 dataChanged = false;
 
+            $scope.datastoreInitialized = false;
             $scope.idEmpty = false;
             /*
              * Go pull any previously saved data
              * */
             buildfire.datastore.get(function (err, result) {
+                if (!err) {
+                    $scope.datastoreInitialized = true;
+                } else {
+                    console.error("Error: ", err);
+                    return;
+                }
+                
                 if (result && result.data && !angular.equals({}, result.data)) {
                     $scope.data = result.data;
                     $scope.id = result.id;
@@ -72,9 +80,14 @@
                     $scope.$apply();
                 }
             });
-           
+
 
             $scope.validateUrl = function () {
+                if (!$scope.datastoreInitialized) {
+                    console.error("Error with datastore didn't get called");
+                    return;
+                }
+
                 if (!dataChanged) {
                     console.warn("data didn't changed")
                     return;
@@ -104,4 +117,5 @@
         }]);
     </script>
 </body>
+
 </html>

--- a/widget/index.html
+++ b/widget/index.html
@@ -3,29 +3,73 @@
 <head lang="en">
     <meta charset="UTF-8">
     <title>widget</title>
-    <script src="../../../scripts/angular/angular.min.js"></script>
+    <script type="text/javascript" src="../../../scripts/angular/angular.min.js"></script>
     <script type="text/javascript" src="../../../scripts/buildfire.js"></script>
+    <style>
+        div.link-verified {
+            height: 100%;
+            min-height: 300px;
+            position: relative;
+            display: none;
+        }
+            /* 1 */
+            div.link-verified > div {
+                margin: 0;
+                position: absolute; /* 2 */
+                top: 50%; /* 3 */
+                transform: translate(0, -50%);
+                width: 100%;
+            }
+
+            div.link-verified .glyphicon {
+                border: 2px solid;
+                padding: 10px;
+                border-radius: 50%;
+                margin-bottom: 20px;
+            }
+    </style>
 </head>
 <body>
+    <div class="text-center link-verified">
+        <div class="col-md-12">
+            <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
+            <p>
+                We were able to verify the link you provided. The link will only appear on your mobile device.
+            </p>
+        </div>
+    </div>
     <script>
         buildfire.spinner.show();
+
+        function dataLoadedHandler(result) {
+            var content = null;
+            if (result && result.data && !angular.equals({}, result.data)) {
+                if (result.data.content) {
+                    content = result.data.content;
+                    buildfire.spinner.hide();
+
+                    if (buildfire.context.device.platform != "web") {
+                        buildfire.navigation.openWindow(content.facebookId, "_system");
+                        buildfire.navigation.goBack();
+                    } else {
+                        document.querySelector(".link-verified").style.display = "block";
+                    }
+                }
+            } else {
+                buildfire.spinner.hide();
+            }
+        }
         /*
          * Go pull saved data
          * */
         var loadData = function () {
             buildfire.datastore.get(function (err, result) {
-                var content = null;
-                if (result && result.data && !angular.equals({}, result.data)) {
-                    if (result.data.content) {
-                        content = result.data.content;
-                        buildfire.navigation.openWindow(content.facebookId, "_system");
-                        buildfire.spinner.hide();
-                        if (buildfire.context.device.platform != "web") {
-                            buildfire.navigation.goBack();
-                        }
-                    }
-                } else {
+                if (err) {
+                    console.error("Error: ", err);
                     buildfire.spinner.hide();
+
+                } else {
+                    dataLoadedHandler(result);
                 }
             });
         }
@@ -37,8 +81,8 @@
          */
         buildfire.datastore.onRefresh(loadData);
 
-        buildfire.datastore.onUpdate(function (e) {
-            loadData();
+        buildfire.datastore.onUpdate(function (result) {
+            dataLoadedHandler(result);
         });
     </script>
 </body>


### PR DESCRIPTION
Handle the case where datastore is not called
Don't navigate to facebook on validation (on cp only)
Use onUpdate method result in the widget
